### PR TITLE
add repo for faf installation

### DIFF
--- a/files/group_abrt-faf-el7-epel-7.repo
+++ b/files/group_abrt-faf-el7-epel-7.repo
@@ -1,0 +1,10 @@
+[group_abrt-faf-el7]
+name=Copr repo for faf-el7 owned by @abrt
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@abrt/faf-el7/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/@abrt/faf-el7/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: enable Copr repo
+  copy: src=group_abrt-faf-el7-epel-7.repo dest=/etc/yum.repos.d/
+
 - name: erase faf packages
   yum: pkg="faf-*" state=absent
   when: faf_force_reinstall


### PR DESCRIPTION
This makes sure that there is repo from which should be faf installed.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>