### PR TITLE
Add package for action delete invalid ureports

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,6 +125,7 @@ faf_action_packages:
   - faf-action-c2p
   - faf-action-cleanup-task-results
   - faf-action-create-problems
+  - faf-action-delete-invalid-ureports
   - faf-action-external-faf
   - faf-action-external-faf-clone-bz
   - faf-action-find-components


### PR DESCRIPTION
New action for deleting old invalid ureports was added to the FAF.

This package installs it.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>