### PR TITLE
Replace yum with generic OS package manager

### DIFF
--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -1,11 +1,11 @@
 - name: install faf web celery packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_web_celery_packages }}"
   tags:
   - packages
 
 - name: install redis package
-  yum : name={{ item }} state=installed
+  package : name={{ item }} state=installed
   with_items:
   - redis
   - python-redis

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,41 +4,41 @@
   copy: src=group_abrt-faf-el7-epel-7.repo dest=/etc/yum.repos.d/
 
 - name: erase faf packages
-  yum: pkg="faf-*" state=absent
+  package: pkg="faf-*" state=absent
   when: faf_force_reinstall
 
 - name: install core faf packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_packages }}"
 
 - name: install faf problem packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_problem_packages }}"
 
 - name: install faf opsys packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_opsys_packages }}"
 
 - name: install faf action packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_action_packages }}"
 
 - name: install faf bugtracker packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_bugtracker_packages }}"
   when: faf_with_bugtrackers
 
 - name: install faf celery packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_celery_packages }}"
   when: faf_with_celery
 
 - name: install faf fedmsg packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_fedmsg_packages }}"
   when: faf_with_fedmsg
 
 - name: install faf solutionfinder packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_solutionfinder_packages }}"
   when: faf_with_solutionfinders

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -1,3 +1,3 @@
 ---
 - name: update faf packages
-  yum: pkg="faf*" state=latest
+  package: pkg="faf*" state=latest

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -8,14 +8,14 @@
   when: not faf_web_on_root
 
 - name: install faf-webui packages
-  yum : name={{ item }} state=latest
+  package : name={{ item }} state=latest
   with_items: "{{ faf_web_packages }}"
 
 - include: celery.yml
   when: faf_with_celery
 
 - name: install faf web symboltransfer packages
-  yum: pkg={{ item }} state=installed
+  package: pkg={{ item }} state=installed
   with_items: "{{ faf_web_symboltransfer_packages }}"
   when: faf_with_symboltransfer
 


### PR DESCRIPTION
Automatically chooses package manager, ie. dnf for Fedora, yum for RHEL.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>