### PR TITLE
Update template for faf configuration file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,9 +9,14 @@ domain: example.org
 # default port for memcached
 memcached_port: 11211
 
-# connectstring to use for faf web & storage in format:
-# driver://user:password@host:port/database
-faf_db_connectstring: postgresql:///faf
+# variables used to automatically create a connectstring
+# connectstring is used for faf web & storage in format:
+# postgresql://user:password@host:port/database
+faf_db_user:
+faf_db_password:
+faf_db_host:
+faf_db_port:
+faf_db_name: faf
 
 # dangerous, delete and re-create PostgreSQL database
 # (will wipe Postgre's data dir and re-create from scratch)

--- a/templates/etc-faf-faf.conf.j2
+++ b/templates/etc-faf-faf.conf.j2
@@ -1,5 +1,7 @@
 #{{ ansible_managed }}
 # Faf site-wide configuration file
+# The settings are overridden by the file specified in
+# FAF_CONFIG_FILE environment variable.
 
 [Main]
 PluginsDir = /etc/faf/plugins/
@@ -7,7 +9,11 @@ TemplatesDir = /etc/faf/templates/
 AutoEnablePlugins = False
 
 [Storage]
-ConnectString = {{ faf_db_connectstring }}
+DBUser = {{ faf_db_user }}
+DBPasswd = {{ faf_db_password }}
+DBHost = {{ faf_db_host }}
+DBPort = {{ faf_db_port }}
+DBName = {{ faf_db_name }}
 LobDir = {{ faf_spool_dir }}/lob
 # Using platform-specific location by default.
 # Uncomment and change if needed.
@@ -30,3 +36,21 @@ CreateComponents = False
 # allowed values: fedora-bugzilla rhel-bugzilla centos-mantisb comment email url
 # or * to allow all attachments
 AcceptAttachments = fedora-bugzilla rhel-bugzilla centos-mantisbt
+
+# Allow uReports without affected package - meaning that crashing code was
+# not packaged
+allow-unpackaged = False
+
+# Determines which strategy will be used for searching known or uknown ureport's
+# and bugzilla bug's, if known is empty, then is used BUG_OS_MINOR_VERSION
+#
+# BUG_OS_MAJOR_VERSION - The report has attached a bug with equivalent OS Major
+# version name
+# BUG_OS_MINOR_VERSION - The report has attached a bug with equivalent OS Major
+# version and OS Minor version name
+# EQUAL_UREPORT_EXISTS - Report OS Major version match AND uReport OS Minor
+# version match AND uReport OS Architecture match AND Packages match name
+#
+# allowed values for the Known option
+# BUG_OS_MAJOR_VERSION BUG_OS_MINOR_VERSION EQUAL_UREPORT_EXISTS
+Known =


### PR DESCRIPTION
abrt/faf@c20eef7ae20f02d0eb72a44e9891e8c59d1b2ff2
- ConnectString is created from variables in configuration file

abrt/faf@d88ee2a444dc69653084c0e8385747476f1380ea
- Accept uReports of crashes from unpackaged code

abrt/faf@4264055bea9277f7bee361dcba8a8f334d64a5a0
- Configurable finding known ureport and buzilla bug's

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>